### PR TITLE
type-hinting fix to allow python3.8 compatibility

### DIFF
--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Dict
 
 import streamlit.components.v1 as components
 import streamlit as st
@@ -7,7 +7,7 @@ import streamlit as st
 # TODO add keyboard hint to button (streamlit-extras)
 # https://arnaudmiribel.github.io/streamlit-extras/extras/keyboard_text/
 
-def add_keyboard_shortcuts(key_combinations: dict[str, str]):
+def add_keyboard_shortcuts(key_combinations: Dict[str, str]):
     """
     Add keyboard shortcuts to trigger Streamlit buttons.
 


### PR DESCRIPTION
Subscripting type hints was introduced in python 3.9+. This change enables use of `streamlit-shortcuts` with python 3.8 as well!

ref: https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections

Relevant error log in python 3.8:
```bash
    def add_keyboard_shortcuts(key_combinations: dict[str, str]):
TypeError: 'type' object is not subscriptable
```
Why (still) python 3.8?
- Python 3.8 is still yet to be EOL as of today
- Is the default version of python in Ubuntu 20.04