### PR TITLE
use keys rather than labels for shortcut assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ The GitHub Actions workflow will automatically create a new release and publish 
     - Keyboard hints
 - @taylor-ennen
     - Fixed usage `flow` of code
+- @sammlapp
+    - Improved specificity of shortcuts to unique elements
+    - add flexibility to select different elements and perform different actions
 
 ## Credits
 Solution inspired by:

--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -3,6 +3,9 @@ from typing import Callable, Dict
 import streamlit.components.v1 as components
 import streamlit as st
 
+if not "button_key_counter" in st.session_state:
+    st.session_state["button_key_counter"] = 1
+
 
 def normalize_key_combination(combo: str) -> str:
     """Normalize key combination to a standard format."""
@@ -77,8 +80,8 @@ def add_keyboard_shortcuts(
 def button(
     label: str,
     shortcut: str,
-    key: str,
     on_click: Callable[..., None],
+    key=None,
     hint=False,
     args=None,
     **kwargs,
@@ -89,9 +92,11 @@ def button(
     Args:
         label (str): The text to display on the button.
         shortcut (str): The keyboard shortcut associated with the button.
-        key (str): The unique key for the button, used to identify it in Streamlit.
         on_click (Callable[..., None]): The function to call when the button is clicked.
-        hint (bool, optional): Whether to show the keyboard shortcut as a hint on the button label. Defaults to False.
+        key (str): The unique id for the button, used to identify it in Streamlit.
+            If None, a unique ID like `button_1` is generated automatically.
+        hint (bool, optional): Whether to show the keyboard shortcut as a hint
+            on the button label. Defaults to False.
         args (tuple, optional): Additional arguments to pass to the on_click function.
         **kwargs: Additional keyword arguments passed to the button function.
 
@@ -99,9 +104,21 @@ def button(
         The result of the Streamlit button function.
 
     Notes:
-        This function integrates with Streamlit's `st.button` to display a button with an optional hint showing the associated
-        keyboard shortcut.
+        This function integrates with Streamlit's `st.button` to display a
+        button with an optional hint showing the associated keyboard shortcut.
     """
+    if key in st.session_state:
+        raise ValueError(
+            f"Key '{key}' is already in use. Please provide a unique key or use `None` to generate a unique key"
+        )
+
+    # generate a unique key if not provided
+    # we use a counter in the session state to ensure uniqueness
+    # and we make sure to not overwrite existing keys
+    while key is None or key in st.session_state:
+        n = st.session_state["button_key_counter"]
+        key = f"button_{n}"
+        st.session_state["button_key_counter"] = n + 1
 
     if hint:
         button_label = f"{label} `{shortcut}`"

--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -107,11 +107,6 @@ def button(
         This function integrates with Streamlit's `st.button` to display a
         button with an optional hint showing the associated keyboard shortcut.
     """
-    if key in st.session_state:
-        raise ValueError(
-            f"Key '{key}' is already in use. Please provide a unique key or use `None` to generate a unique key"
-        )
-
     # generate a unique key if not provided
     # we use a counter in the session state to ensure uniqueness
     # and we make sure to not overwrite existing keys

--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -12,12 +12,15 @@ def normalize_key_combination(combo: str) -> str:
     return "+".join(modifiers + other_keys)
 
 
-def add_keyboard_shortcuts(keys_shortrcuts_dict: Dict[str, str]):
+def add_keyboard_shortcuts(
+    keys_shortrcuts_dict: Dict[str, str], target_element="button"
+):
     """add shortcuts
 
     Args:
         keys_shortrcuts_dict (Dict[str, str]): A dictionary where keys are the streamlit 'key' of the target button
             and values are the keyboard shortcuts such as 'a', 'ctrl+shift+k' or 'cmd+enter'.
+        target_element (str): The type of HTML element to target for the click event. Defaults to "button".
     """
     if not isinstance(keys_shortrcuts_dict, dict):
         raise TypeError("key_combinations must be a dictionary of key:shortcut pairs.")
@@ -54,7 +57,7 @@ def add_keyboard_shortcuts(keys_shortrcuts_dict: Dict[str, str]):
         js_code += f"""
         if (checkCombo(e, '{normalized_combo}')) {{
             e.preventDefault();
-            const button = doc.querySelector('.st-key-{key}').querySelector('button');
+            const button = doc.querySelector('.st-key-{key}').querySelector('{target_element}');
             if (button) {{
                 button.click();
             }}

--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -13,14 +13,16 @@ def normalize_key_combination(combo: str) -> str:
 
 
 def add_keyboard_shortcuts(
-    keys_shortrcuts_dict: Dict[str, str], target_element="button"
+    keys_shortrcuts_dict: Dict[str, str], target_element="button", action="click()"
 ):
     """add shortcuts
 
     Args:
-        keys_shortrcuts_dict (Dict[str, str]): A dictionary where keys are the streamlit 'key' of the target button
+        keys_shortrcuts_dict (Dict[str, str]): A dictionary where keys are the streamlit id (key) of the target button
             and values are the keyboard shortcuts such as 'a', 'ctrl+shift+k' or 'cmd+enter'.
         target_element (str): The type of HTML element to target for the click event. Defaults to "button".
+        action (str): The action to perform on the target element. Defaults to "click".
+            - calls element.`action` in JS, so action should be a method of the element
     """
     if not isinstance(keys_shortrcuts_dict, dict):
         raise TypeError("key_combinations must be a dictionary of key:shortcut pairs.")
@@ -52,14 +54,14 @@ def add_keyboard_shortcuts(
     """
 
     for key, shortcut in keys_shortrcuts_dict.items():
-        # to select the element, we find the div with the class 'st-key-{key}', then find the button within it
+        # to select the element, we find the div with the class 'st-key-{key}', then find the element within it
         normalized_combo = normalize_key_combination(shortcut)
         js_code += f"""
         if (checkCombo(e, '{normalized_combo}')) {{
             e.preventDefault();
-            const button = doc.querySelector('.st-key-{key}').querySelector('{target_element}');
-            if (button) {{
-                button.click();
+            const element = doc.querySelector('.st-key-{key}').querySelector('{target_element}');
+            if (element) {{
+                element.{action};
             }}
         }}
         """

--- a/tests/test_streamlit_shortcuts.py
+++ b/tests/test_streamlit_shortcuts.py
@@ -12,7 +12,7 @@ def test_button_exists():
 
 def test_add_keyboard_shortcuts_accepts_dict():
     try:
-        add_keyboard_shortcuts({"ctrl+t": "Test"})
+        add_keyboard_shortcuts({"test": "ctrl+t"})
     except TypeError:
         pytest.fail("add_keyboard_shortcuts should accept a dictionary")
 
@@ -26,10 +26,17 @@ def test_button_accepts_arguments():
     def dummy_callback():
         pass
 
-    result = button("Test", "ctrl+t", dummy_callback)
+    result = button("Test", "ctrl+t", key="test", on_click=dummy_callback)
+    assert result is not None, "button should return a value"
+
+    def dummy_callback2(x, y):
+        pass
+
+    result = button("Test", "ctrl+t", key="test", on_click=dummy_callback, args=(1, 2))
     assert result is not None, "button should return a value"
 
 
 def test_button_rejects_invalid_arguments():
+    # label should be a string, this should raise TypeError
     with pytest.raises(TypeError):
-        button(123, "ctrl+t", lambda: None)  # label should be a string
+        button(123, "ctrl+t", key="abc", on_click=lambda: None)


### PR DESCRIPTION
resolves https://github.com/adriangalilea/streamlit-shortcuts/issues/17

changes the API of button and add_keyboard_shortcuts:
now expects a dictionary mapping _streamlit keys_ to shortcuts

in the JS snippet, we first find the element with the matching key (by matching the class `st-key-{key}`, then we find the `button` element within that element. I also expose an argument for 'target_element', with the default being button. The user can decide to look for a different type of element within the element matched by `st-key-{key}`. Note that I use .querySelector, which returns the first of any matching elements. 

Previously, the js element was selected only based on the text containing the label text, which was prone to various bugs and meant that icons could not be used in the labels of elements with shortcuts. 

This solution will allow keyboard shortcuts to be added to various elements. 

Further generalization could be added to allow shortcuts for methods other than 'click'. For instance, the user could call other methods of a selected element. 