### PR TITLE
Fixed example code and tweaked search for element container

### DIFF
--- a/example.py
+++ b/example.py
@@ -28,8 +28,15 @@ def main():
 
     # Example 4: Custom target_element and action
     st.caption("Press Shift+F to focus on the text input field below.")
-    title = st.text_input("Email addresss", placeholder="user@domain.com", key="movietitle", help="This example makes use of the `target_element` and `action` parameters")
-    add_keyboard_shortcuts({"movietitle": "shift+f"}, target_element="input", action="focus()")
+    st.text_input(
+        "Email address",
+        placeholder="user@domain.com",
+        key="movietitle",
+        help="This example makes use of the `target_element` and `action` parameters",
+    )
+    add_keyboard_shortcuts(
+        {"movietitle": "shift+f"}, target_element="input", action="focus()"
+    )
 
     # Button with shortcut to show a message with a link
     def open_link_message():

--- a/example.py
+++ b/example.py
@@ -12,12 +12,12 @@ def main():
         st.write("Button was clicked")
 
     # Example 2: Multiple shortcuts
-    add_keyboard_shortcuts({"ctrl+shift+s": "Save", "ctrl+shift+o": "Open"})
+    add_keyboard_shortcuts({"Save": "ctrl+shift+s", "Open": "ctrl+shift+o"})
 
-    if st.button("Save"):
+    if st.button("Save", key="Save"):
         st.success("Saved! (You can also press Ctrl+Shift+S)")
 
-    if st.button("Open"):
+    if st.button("Open", key="Open"):
         st.success("Opened! (You can also press Ctrl+Shift+O)")
 
     # Example 3: Button with arguments
@@ -25,6 +25,11 @@ def main():
         st.success(f"Hello, {name}!")
 
     button("Greet", "ctrl+shift+g", greet, hint=True, args=("World",))
+
+    # Example 4: Custom target_element and action
+    st.caption("Press Shift+F to focus on the text input field below.")
+    title = st.text_input("Email addresss", placeholder="user@domain.com", key="movietitle", help="This example makes use of the `target_element` and `action` parameters")
+    add_keyboard_shortcuts({"movietitle": "shift+f"}, target_element="input", action="focus()")
 
     # Button with shortcut to show a message with a link
     def open_link_message():

--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -16,18 +16,18 @@ def normalize_key_combination(combo: str) -> str:
 
 
 def add_keyboard_shortcuts(
-    keys_shortrcuts_dict: Dict[str, str], target_element="button", action="click()"
+    keys_shortcuts_dict: Dict[str, str], target_element="button", action="click()"
 ):
     """add shortcuts
 
     Args:
-        keys_shortrcuts_dict (Dict[str, str]): A dictionary where keys are the streamlit id (key) of the target button
+        keys_shortcuts_dict (Dict[str, str]): A dictionary where keys are the streamlit id (key) of the target button
             and values are the keyboard shortcuts such as 'a', 'ctrl+shift+k' or 'cmd+enter'.
         target_element (str): The type of HTML element to target for the click event. Defaults to "button".
         action (str): The action to perform on the target element. Defaults to "click()".
             - calls element.`action` in JS, so action should be a method of the element along with any parameters.
     """
-    if not isinstance(keys_shortrcuts_dict, dict):
+    if not isinstance(keys_shortcuts_dict, dict):
         raise TypeError("key_combinations must be a dictionary of key:shortcut pairs.")
 
     js_code = """
@@ -56,7 +56,7 @@ def add_keyboard_shortcuts(
     doc.addEventListener('keydown', function(e) {
     """
 
-    for key, shortcut in keys_shortrcuts_dict.items():
+    for key, shortcut in keys_shortcuts_dict.items():
         # to select the element, we find the div with the class 'st-key-{key}', then find the element within it
         normalized_combo = normalize_key_combination(shortcut)
         js_code += f"""

--- a/src/streamlit_shortcuts/streamlit_shortcuts.py
+++ b/src/streamlit_shortcuts/streamlit_shortcuts.py
@@ -24,8 +24,8 @@ def add_keyboard_shortcuts(
         keys_shortrcuts_dict (Dict[str, str]): A dictionary where keys are the streamlit id (key) of the target button
             and values are the keyboard shortcuts such as 'a', 'ctrl+shift+k' or 'cmd+enter'.
         target_element (str): The type of HTML element to target for the click event. Defaults to "button".
-        action (str): The action to perform on the target element. Defaults to "click".
-            - calls element.`action` in JS, so action should be a method of the element
+        action (str): The action to perform on the target element. Defaults to "click()".
+            - calls element.`action` in JS, so action should be a method of the element along with any parameters.
     """
     if not isinstance(keys_shortrcuts_dict, dict):
         raise TypeError("key_combinations must be a dictionary of key:shortcut pairs.")
@@ -62,9 +62,14 @@ def add_keyboard_shortcuts(
         js_code += f"""
         if (checkCombo(e, '{normalized_combo}')) {{
             e.preventDefault();
-            const element = doc.querySelector('.st-key-{key}').querySelector('{target_element}');
-            if (element) {{
-                element.{action};
+            const container = doc.querySelector('.st-key-{key}');
+            if (container) {{
+                const element = container.querySelector('{target_element}');
+                if (element) {{
+                    element.{action};
+                }}
+            }} else {{
+                console.warn("streamlit-shortcuts: Unable to find container with key '{key}'.");
             }}
         }}
         """


### PR DESCRIPTION
This PR does two things:

1. Fix a bug in the example provided (see #25) and add a new example. Example 4 illustrates the use of a custom `target_element` (an input field instead of a button) and a custom `action` (`focus()` instead of `click()`). See below:

![image](https://github.com/user-attachments/assets/cb76c7ce-285d-46d1-a431-f644e7dddfaa)

2. Modify the way we look for the container div with the provided `key` in `add_keyboard_shortcuts()`. Previously if the container did not exist on the page, the browser would throw a runtime error on the JS side. Now we provide a helpful warning in the console instead.